### PR TITLE
[MIN-1126] fix stake withdrawal fee calculation

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1746,7 +1746,13 @@ impl Withdrawals {
 impl From<&Withdrawals> for RequiredSignersSet {
     fn from(withdrawals: &Withdrawals) -> Self {
         withdrawals.0.iter().fold(BTreeSet::new(), |mut set, w| {
-            set.insert((*w.0).payment_cred().to_keyhash().unwrap());
+            let payment_cred = (*w.0).payment_cred();
+            let kind = payment_cred.kind();
+            if kind == StakeCredKind::Key {
+                if let Some(keyhash) = payment_cred.to_keyhash() {
+                    set.insert(keyhash);
+                }
+            }
             set
         })
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1743,6 +1743,15 @@ impl Withdrawals {
     }
 }
 
+impl From<&Withdrawals> for RequiredSignersSet {
+    fn from(withdrawals: &Withdrawals) -> Self {
+        withdrawals.0.iter().fold(BTreeSet::new(), |mut set, w| {
+            set.insert((*w.0).payment_cred().to_keyhash().unwrap());
+            set
+        })
+    }
+}
+
 impl serde::Serialize for Withdrawals {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -2242,7 +2242,6 @@ mod tests {
     fn build_tx_withdraw() {
         let mut tx_builder: TransactionBuilder = create_default_tx_builder();
         let payment_addr = Address::from_bech32("addr_test1qrev489ndc4n5rvcscce4ug2nqrcg3f93u9nq0z6lfrqgwpcc8ypmmlrlz4sgak8azdp8jeqv5psgvdlk7jvl5ht8ruquf04vw").unwrap();
-        let change_addr = Address::from_bech32("addr_test1qrev489ndc4n5rvcscce4ug2nqrcg3f93u9nq0z6lfrqgwpcc8ypmmlrlz4sgak8azdp8jeqv5psgvdlk7jvl5ht8ruquf04vw").unwrap();
         let input = TransactionInput::new(
             &TransactionHash::from_hex(
                 "ecc0d58b2a997056cbb3c70b8ea166f3f29305bb1bc14fade0ebc5298093dca2",
@@ -2267,7 +2266,7 @@ mod tests {
         );
     
         tx_builder.set_withdrawals(&withdrawals);
-        tx_builder.add_change_if_needed(&change_addr).unwrap();
+        tx_builder.add_change_if_needed(&payment_addr).unwrap();
         assert_eq!(
             tx_builder
                 .get_explicit_input()

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -2022,7 +2022,6 @@ impl TransactionBuilder {
 
 #[cfg(test)]
 mod tests {
-
     use super::output_builder::TransactionOutputBuilder;
     use super::*;
     use crate::fakes::{fake_base_address, fake_bytes_32, fake_key_hash, fake_policy_id, fake_tx_hash, fake_tx_input, fake_tx_input2, fake_value, fake_value2};

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -143,6 +143,9 @@ fn count_needed_vkeys(tx_builder: &TransactionBuilder) -> usize {
     if let Some(scripts) = &tx_builder.mint_scripts {
         input_hashes.extend(RequiredSignersSet::from(scripts));
     }
+    if let Some(withdrawals) = &tx_builder.withdrawals {
+        input_hashes.extend(RequiredSignersSet::from(withdrawals));
+    }
     input_hashes.len()
 }
 
@@ -2019,6 +2022,8 @@ impl TransactionBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Add;
+
     use super::output_builder::TransactionOutputBuilder;
     use super::*;
     use crate::fakes::{fake_base_address, fake_bytes_32, fake_key_hash, fake_policy_id, fake_tx_hash, fake_tx_input, fake_tx_input2, fake_value, fake_value2};
@@ -2231,6 +2236,51 @@ mod tests {
         assert_eq!(tx_builder.full_size().unwrap(), 285);
         assert_eq!(tx_builder.output_sizes(), vec![62, 65]);
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
+    }
+
+    #[test]
+    fn build_tx_withdraw() {
+        let mut tx_builder: TransactionBuilder = create_default_tx_builder();
+        let payment_addr = Address::from_bech32("addr_test1qrev489ndc4n5rvcscce4ug2nqrcg3f93u9nq0z6lfrqgwpcc8ypmmlrlz4sgak8azdp8jeqv5psgvdlk7jvl5ht8ruquf04vw").unwrap();
+        let change_addr = Address::from_bech32("addr_test1qrev489ndc4n5rvcscce4ug2nqrcg3f93u9nq0z6lfrqgwpcc8ypmmlrlz4sgak8azdp8jeqv5psgvdlk7jvl5ht8ruquf04vw").unwrap();
+        let input = TransactionInput::new(
+            &TransactionHash::from_hex(
+                "ecc0d58b2a997056cbb3c70b8ea166f3f29305bb1bc14fade0ebc5298093dca2",
+            )
+            .unwrap(),
+            2,
+        );
+        
+        tx_builder.add_input(
+            &payment_addr,
+            &input,
+            &Value::new(&BigNum::from_str("5736075744").unwrap()),
+        );
+    
+    
+        let stake_addr = Address::from_bech32("stake_test1uquvrjqaal3l32cywmr73xsnevsx2qcyxxlm0fx06t4n37qpxp68z").unwrap();
+    
+        let mut withdrawals = Withdrawals::new();
+        withdrawals.insert(
+            &RewardAddress::from_address(&stake_addr).unwrap(),
+            &BigNum::from_str("7175949").unwrap(),
+        );
+    
+        tx_builder.set_withdrawals(&withdrawals);
+        tx_builder.add_change_if_needed(&change_addr).unwrap();
+        assert_eq!(
+            tx_builder
+                .get_explicit_input()
+                .unwrap()
+                .checked_add(&tx_builder.get_implicit_input().unwrap())
+                .unwrap(),
+            tx_builder
+                .get_explicit_output()
+                .unwrap()
+                .checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap()))
+                .unwrap()
+        );
+        assert_eq!(&tx_builder.get_fee_if_set().unwrap(), &BigNum::from_str("183002").unwrap());
     }
 
     #[test]

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -2022,7 +2022,6 @@ impl TransactionBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Add;
 
     use super::output_builder::TransactionOutputBuilder;
     use super::*;


### PR DESCRIPTION
CSL doesn't calculate tx size correctly for stakewithdraw signing. Fake txn requires to also consider vkey from stake withdrawal.